### PR TITLE
Fix path sanitization of colon

### DIFF
--- a/test/test_reference.py
+++ b/test/test_reference.py
@@ -16,6 +16,11 @@ def clean(string):
     return [l + "\n" for l in string.split("\n")]
 
 
+class TestSanitize(unittest.TestCase):
+    def test_gha_expression(self):
+        self.assertEqual(sanitize("Reference test: ${{ matrix.test }}"), "Reference_test_{{_matrix.test_}}")
+
+
 class TestReferenceWorkflows(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None


### PR DESCRIPTION
```
 Error: The path for one of the files in artifact is not valid: /service-config.yaml/job=Reference_test:_{{_matrix.test_}}/step=Compare_to_reference.sh. Contains the following character:  Colon :
```